### PR TITLE
Separate PRs by manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "group:allNonMajor",
     "schedule:nonOfficeHours"
   ],
   "vulnerabilityAlerts": {
@@ -11,5 +10,18 @@
     ],
     "schedule": "at any time"
   },
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "groupName": "{{manager}} non-major dependencies",
+      "groupSlug": "{{manager}}-minor-patch",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This should avoid bumping ruby while also bumping gems for instance to allow more control over when to upgrade language versions.

See https://github.com/renovatebot/renovate/discussions/16419
