### PR TITLE
Exclude ruby from matched patterns to group

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,8 @@
       "groupName": "{{manager}} non-major dependencies",
       "groupSlug": "{{manager}}-minor-patch",
       "matchPackagePatterns": [
-        "*"
+        "*",
+        "!ruby"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
Things are a bit weird because ruby is updated by both bundler and ruby-version managers in renovate so splitting them by package makes things break. This is an attempt to have our global rule not group ruby so we can focus on a rule specific in the ruby config.
