### PR TITLE
Update: base branch

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -3,6 +3,9 @@
   "extends": [
     "github>MITLibraries/renovate-config"
   ],
+  "baseBranches": [
+    "dev"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
This forces the "dev" branch as the default branch for Terraform. This is fine for all our "workloads" repositories, but will need to be overridden for a few of our repos.
