### PR TITLE
Add pre-comment checks

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -5,7 +5,10 @@
   ],
   "baseBranches": [
     "dev"
-  ],
+  ],,
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackageNames": [
@@ -24,6 +27,12 @@
         "/terraform-aws-modules/"
       ],
       "groupName": "terraform-aws-modules"
+    },
+    {
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "groupName": "pre-commit"
     }
   ]
 }


### PR DESCRIPTION
This adds checks for pre-commit and groups those dependency updates together into one PR.

Note that pre-commit support in Renovate is still in beta. See [Renovate pre-commit beta](https://docs.renovatebot.com/modules/manager/pre-commit/) for details.

This was tested locally in a repository first and behaved as expected.