### PR TITLE
Fixes for Terraform Repositories

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -7,7 +7,10 @@
     "dev"
   ],
   "pre-commit": {
-    "enabled": true
+    "enabled": true,
+    "automerge": false,
+    "labels": ["dependencies", "pre-commit"],
+    "semanticCommits": "enabled"
   },
   "packageRules": [
     {


### PR DESCRIPTION
### Why these changes are being introduced

Renovate/Mend has some issues with the pre-commit hooks dependencies in our Terraform repositories (see [PR#15 in mitlib-tf-workloads-tacos](https://github.com/MITLibraries/mitlib-tf-workloads-tacos/pull/15) as an example). This is an attempt to address that cycling behavior.

### How this addresses that need

* Add additional settings to the pre-commit configuration to see if this will fix the cycling behavior.

