### PR TITLE
Disables lockfile maintenance

### DIFF
--- a/renovate-ruby.json
+++ b/renovate-ruby.json
@@ -3,5 +3,8 @@
   "extends": [
     "github>MITLibraries/renovate-config",
     "group:rubyOnRails"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Lockfile maintenance regenerate the entire lock file and ignores our desire to update major/minor updates separately.

### Why these changes are being introduced

A sentence or two explaining why these changes are here.

### How this addresses that need

Describe the details of the changes.

### Side effects of this change

Are there any side effects? Dependency changes?

### Relevant ticket(s)


* https://mitlibraries.atlassian.net/browse/[X]
