### PR TITLE
Update Shared Terraform Config

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -6,6 +6,9 @@
   "baseBranches": [
     "dev"
   ],
+  "github-actions": {
+    "pinDigests": false
+  },
   "pre-commit": {
     "enabled": true,
     "automerge": true,
@@ -17,7 +20,7 @@
       "matchPackageNames": [
         "hashicorp/aws"
       ],
-      "allowedVersions": "<6.0.0"
+      "allowedVersions": "<7.0.0"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
### Why these changes are being introduced

Two issues are addressed in this update: allow the AWS Provider to be updated to version 6.x and disable digest pinning for caller workflows.

### How this addresses that need

* Update the max AWS Provider version to include 6.x
* Add a `github-actions` stanza to disable digest pinning in caller workflows

### Side effects of this change

No side effects.
