### PR TITLE
Another Attempt to fix PinDigest Issue for Terraform Repositories

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -1,14 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>MITLibraries/renovate-config"
-  ],
-  "baseBranches": [
-    "dev"
-  ],
-  "github-actions": {
-    "pinDigests": false
-  },
+  "extends": ["local>MITLibraries/renovate-config"],
+  "baseBranches": ["dev"],
   "pre-commit": {
     "enabled": true,
     "automerge": true,
@@ -17,28 +10,29 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": [
-        "hashicorp/aws"
-      ],
+      "description": "Disable digest pinning for GitHub Actions in shared workflows",
+      "matchManagers": ["github-actions"],
+      "pinDigests": false
+    },
+    {
+      "description": "Enable pre-commit updates",
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit"
+    },
+    {
+      "description": "Restrict the AWS Provider to v6.x or lower",
+      "matchPackageNames": ["hashicorp/aws"],
       "allowedVersions": "<7.0.0"
     },
     {
-      "matchPackageNames": [
-        "hashicorp/terraform"
-      ],
+      "description": "Restrict the Terraform Provider to v1.x or lower",
+      "matchPackageNames": ["hashicorp/terraform"],
       "allowedVersions": "<2.0.0"
     },
     {
-      "matchPackageNames": [
-        "/terraform-aws-modules/"
-      ],
+      "description": "Group together checks for terraform-aws-modules",
+      "matchPackageNames": ["/terraform-aws-modules/"],
       "groupName": "terraform-aws-modules"
-    },
-    {
-      "matchManagers": [
-        "pre-commit"
-      ],
-      "groupName": "pre-commit"
     }
   ]
 }


### PR DESCRIPTION
### Why these changes are being introduced

The last attempt to get Renovate to stop generating PRs for digest pinning for shared GitHub Actions did not work as expected. This is another attempt and hopefully this one works!

### How this addresses that need

* Remove the "github-actions" block from the `renovate-terraform.json` config file (since it did not do what I expected it to do)
* Add a "matchManagers" check for `"github-actions"` and then disable the `pinDigest` check
* Since we are extending a config that is in the same repository, we shift the reference from `github>` to `local>` in the `"extends"` block

### Side effects of this change

None.


