### PR TITLE
Excludes python from default package grouping

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,7 +19,9 @@
         "*"
       ],
       "matchPackageNames": [
-        "!ruby"
+        "!ruby",
+        "!python",
+        "!public.ecr.aws/lambda/python"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
This matches how we exclude ruby and is causing issues with downstream config