### PR TITLE
Monthly Terraform Schedule

### DIFF
--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -1,10 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>MITLibraries/renovate-config"],
+  "extends": [
+    "local>MITLibraries/renovate-config"
+  ],
   "baseBranches": ["dev"],
   "pre-commit": {
     "enabled": true,
     "automerge": true,
+    "timezone": "America/New_York",
+    "schedule": ["* 0-5 2 * *"],
     "labels": ["dependencies", "pre-commit"],
     "semanticCommits": "enabled"
   },
@@ -15,9 +19,11 @@
       "pinDigests": false
     },
     {
-      "description": "Enable pre-commit updates",
+      "description": "Enable pre-commit updates once per month",
       "matchManagers": ["pre-commit"],
-      "groupName": "pre-commit"
+      "groupName": "pre-commit",
+      "timezone": "America/New_York",
+      "schedule": ["* 0-5 1 * *"]
     },
     {
       "description": "Restrict the AWS Provider to v6.x or lower",


### PR DESCRIPTION
### Why these changes are being introduced

The current schedule for Terraform-related dependencies is too often and too noisy. After reviewing the past few months worth of suggestions from Renovate, it seems much more reasonable to switch to a monthly check by Renovate.

### How this addresses that need

* Switch the Renovate schedule for Terraform to once-per-month.

### Side effects of this change

None.

### Relevant ticket(s)

* [IN-1763](https://mitlibraries.atlassian.net/browse/IN-1763)
* [IN-1764](https://mitlibraries.atlassian.net/browse/IN-1764)


[IN-1763]: https://mitlibraries.atlassian.net/browse/IN-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1764]: https://mitlibraries.atlassian.net/browse/IN-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ